### PR TITLE
Evaluate generator so recommendation rankings aren't lost

### DIFF
--- a/recommends/algorithms/ghetto.py
+++ b/recommends/algorithms/ghetto.py
@@ -51,7 +51,7 @@ class GhettoAlgorithm(BaseAlgorithm):
                         totalSim[item2] += similarity
 
             # Divide each total score by total weighting to get an average
-            rankings = ((item, (score / totalSim[item])) for item, score in scores.iteritems() if totalSim[item] != 0)
+            rankings = [(item, (score / totalSim[item])) for item, score in scores.iteritems() if totalSim[item] != 0]
             return rankings
         return []
 


### PR DESCRIPTION
I had an issue where recommendations were never being saved because the generator was evaluated at some point, and then later showing up as an empty list. This change seems to fix that issue. Was there a reason this was written this way? Have you noticed this issue where no recommendations are saved using the ghetto algorithm?