### PR TITLE
Django 1.8 compatibility (partial)

### DIFF
--- a/recommends/managers.py
+++ b/recommends/managers.py
@@ -12,7 +12,7 @@ class CachedContentTypesMixin():
 
     def get_ctype_id_for_obj(self, obj):
         app_label = obj._meta.app_label
-        module_name = obj._meta.module_name
+        module_name = obj._meta.model_name
         return self.ctypes["%s.%s" % (app_label, module_name)]
 
 

--- a/recommends/storages/djangoorm/managers.py
+++ b/recommends/storages/djangoorm/managers.py
@@ -28,8 +28,8 @@ class SimilarityManager(RecommendsManager):
             related_object_id=related_obj.id
         )
 
-    def get_query_set(self):
-        return super(SimilarityManager, self).get_query_set().filter(score__isnull=False)
+    def get_queryset(self):
+        return super(SimilarityManager, self).get_queryset().filter(score__isnull=False)
 
     def get_or_create_for_objects(self, object_target, object_target_site, object_related, object_related_site):
         object_ctype_id = self.get_ctype_id_for_obj(object_target)
@@ -67,8 +67,8 @@ class SimilarityManager(RecommendsManager):
 
 
 class RecommendationManager(RecommendsManager):
-    def get_query_set(self):
-        return super(RecommendationManager, self).get_query_set().filter(score__isnull=False)
+    def get_queryset(self):
+        return super(RecommendationManager, self).get_queryset().filter(score__isnull=False)
 
     def get_or_create_for_object(self, user, object_recommended, object_site):
         object_ctype_id = self.get_ctype_id_for_obj(object_recommended)


### PR DESCRIPTION
Fixes 2 `RemovedInDjango18Warnings`:
- `Manager.get_query_set` -> `Manager.get_queryset`
- `obj._meta.module_name` -> `obj._meta.model_name`
### Disclaimer

This PR doesn't fix one deprecation warning:
TBD: `Fix recommends/storages/djangoorm/storage.py:45: RemovedInDjango18Warning: commit_manually is deprecated`

Django transaction management was substantially changed in 1.6,
providing correct atomic behavior. Old api is removed in 1.8, leaving
an open problem supporting same codebase prior Django 1.6.
One way to do it is drop 1.4 & 1.5 support (1.5 has already reached EOL,
1.4 will probably have its cycle [finished by March of 2015](https://docs.djangoproject.com/en/1.7/internals/release-process/#long-term-support-lts-releases)).
Another way is to make a compatibility wrapper or something like that
to keep 1.4 support (might be tricky).

In case you decide to drop 1.4&1.5 django support, this commit
could be simplified, leaving only one code branch.
