### PR TITLE
Convert type of identifier from byte to str

### DIFF
--- a/recommends/converters.py
+++ b/recommends/converters.py
@@ -41,6 +41,7 @@ class IdentifierManager(object):
         """
         The opposite of ``get_identifier()``
         """
+        identifier = identifier.decode('utf-8')
         app_module, site_id, object_id = identifier.split(':')
         ctype = self.ctypes[app_module]
 


### PR DESCRIPTION
Django: 1.9.7
redis-server: 3.2.8
storage: Redis

When I executed `self.provider.storage.get_recommendations_for_user(user1)`, it occurs error:

```
Traceback (most recent call last):
  File "/Users/Chois/Dropbox/Workspace/django/spacegraphy-project/spacegraphy/recommendation/tests/test_recommendation.py", line 56, in test_recommandation_and_similarities_reset_when_product_deactivated
    before_recommendations = self.provider.storage.get_recommendations_for_user(user1)
  File "/Users/Chois/.pyenv/versions/spacegraphy/lib/python3.5/site-packages/recommends/storages/redis/storage.py", line 61, in get_recommendations_for_user
    recommendation_dicts = [self.identifier_manager.identifier_to_dict(object_id, score) for object_id, score in scores]
  File "/Users/Chois/.pyenv/versions/spacegraphy/lib/python3.5/site-packages/recommends/storages/redis/storage.py", line 61, in <listcomp>
    recommendation_dicts = [self.identifier_manager.identifier_to_dict(object_id, score) for object_id, score in scores]
  File "/Users/Chois/.pyenv/versions/spacegraphy/lib/python3.5/site-packages/recommends/converters.py", line 44, in identifier_to_dict
    app_module, site_id, object_id = identifier.split(':')
TypeError: a bytes-like object is required, not 'str'
```



I debug it and I found out this:
**storage.py (redis)** 
```
def get_recommendations_for_user(self, user, limit=10, raw_id=False):
    .
    .
    .
    scores = r.zrevrangebyscore(key, min=0, max=1, num=limit, start=0, withscores=True)

    print(scores)
    .
    .
```

(I break the code with `IPython embed()`)

```
In [1]: scores
Out[1]: [(b'products.product:1:5', 1.0), (b'products.product:1:4', 1.0)]
```

So I changed the code of `converters.py` so that it works no matter what `identifier` type is.

