### PR TITLE
Check identifier type before decoding it

### DIFF
--- a/recommends/converters.py
+++ b/recommends/converters.py
@@ -41,7 +41,8 @@ class IdentifierManager(object):
         """
         The opposite of ``get_identifier()``
         """
-        identifier = identifier.decode('utf-8')
+        if type(identifier) is not str:
+            identifier = identifier.decode('utf-8')
         app_module, site_id, object_id = identifier.split(':')
         ctype = self.ctypes[app_module]
 


### PR DESCRIPTION
I missed type-checking before decoding.

If I didn't check identifier type, it occurs an error at:

```
def get_similarities_for_object(self, obj, limit=10, raw_id=False):
    .
    .
    .
    similarity_dict = self.identifier_manager.identifier_to_dict(object_id)  # => object id is str type...
    .
    .
```

Sorry for my mistake.

Thanks.

