### PR TITLE
Change deprecated options_list to add_arguments

### DIFF
--- a/recommends/management/commands/recommends_precompute.py
+++ b/recommends/management/commands/recommends_precompute.py
@@ -3,21 +3,19 @@ from recommends.tasks import recommends_precompute
 
 from datetime import datetime
 import dateutil.relativedelta
-from optparse import make_option
 
 import warnings
 
 
 class Command(BaseCommand):
     help = 'Calculate recommendations and similarities based on ratings'
-    option_list = BaseCommand.option_list + (
-        make_option('--verbose',
-            action='store_true',
-            dest='verbose',
-            default=False,
-            help='verbose mode'
-        ),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--verbose',
+                            action='store_true',
+                            dest='verbose',
+                            default=False,
+                            help='verbose mode')
 
     def handle(self, *args, **options):
         verbosity = int(options.get('verbosity', 0))


### PR DESCRIPTION
About https://github.com/fcurella/django-recommends/issues/35

Changed deprecated [option_list of Django 1.7](https://docs.djangoproject.com/en/1.7/howto/custom-management-commands/#custom-commands-options) to [add_arguments from Django 1.8](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#custom-commands-options).