### PR TITLE
Constrain Celery version to >=3.0 OR < 5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.7
-celery>=3.0
+celery>=3.0,<5.0
 python-dateutil>=2.1


### PR DESCRIPTION
Celery version 5 introduces breaking changes which does not allow the django-recommends app to function properly. See https://github.com/celery/celery/issues/6406#issuecomment-707148978